### PR TITLE
fix: switch default Gemini selection to 2.5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ Pour activer l'intégration Gemini :
 1.  Ajoutez le secret `GEMINI_API_KEY` dans les paramètres de votre dépôt GitHub (Settings > Secrets and variables > Actions).
 2.  L'action se déclenchera automatiquement lors de la création d'une issue ou l'ajout d'un label.
 
+### Réglages recommandés (performance + choix des modèles)
+
+Vous pouvez aussi configurer ces variables/inputs optionnels pour améliorer la latence et la robustesse :
+
+- `GEMINI_MODEL` : modèle principal (défaut : `gemini-2.5-flash`).
+- `GEMINI_FALLBACK_MODELS` : modèles de secours séparés par des virgules.
+- `GEMINI_RETRIES` : nombre de tentatives en cas d'erreur API.
+
+Exemple :
+
+```txt
+GEMINI_MODEL=gemini-2.5-flash
+GEMINI_FALLBACK_MODELS=gemini-2.5-pro
+GEMINI_RETRIES=2
+```
+
 ## Architecture
 
 Le projet suit l'architecture définie dans `.kiro/specs`.

--- a/__tests__/properties/retry-logic.test.js
+++ b/__tests__/properties/retry-logic.test.js
@@ -12,10 +12,12 @@ describe('Property 7: Retry Logic Behavior', () => {
         fc.integer({ min: 0, max: 5 }), // actual failures
         fc.integer({ min: 1, max: 3 }), // allowed retries
         async (failCount, allowedRetries) => {
-          const client = new GeminiClient(apiKey, 'gemini-1.5-flash', mockDelay);
+          const client = new GeminiClient(apiKey, 'gemini-2.5-flash', mockDelay);
+          const mockModel = { generateContent: jest.fn() };
+          client.getModel = jest.fn(() => mockModel);
           
           let callCount = 0;
-          client.model.generateContent = jest.fn().mockImplementation(() => {
+          mockModel.generateContent.mockImplementation(() => {
             callCount++;
             if (callCount <= failCount) {
               throw new Error('API Error');

--- a/action.js
+++ b/action.js
@@ -17,7 +17,11 @@ async function run() {
     }
 
     const githubClient = new GitHubClient(config.githubToken, config.githubRepo);
-    const geminiClient = new GeminiClient(config.geminiApiKey);
+    const geminiClient = new GeminiClient(config.geminiApiKey, {
+      primaryModel: config.geminiModel,
+      fallbackModels: config.geminiFallbackModels,
+      retries: config.geminiRetries
+    });
     const analyzer = new IssueAnalyzer(geminiClient);
     const branchManager = new BranchManager(githubClient);
     const workflow = new WorkflowManager(githubClient, geminiClient, analyzer, branchManager);

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,15 @@ inputs:
   gemini-api-key:
     description: 'API Key for Google Gemini'
     required: true
+  gemini-model:
+    description: 'Primary Gemini model (e.g. gemini-2.5-flash)'
+    required: false
+  gemini-fallback-models:
+    description: 'Comma-separated fallback Gemini models'
+    required: false
+  gemini-retries:
+    description: 'Retry count for Gemini API calls'
+    required: false
   github-token:
     description: 'GitHub Token'
     required: true

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,8 +1,17 @@
 import * as core from '@actions/core';
 
 export function getConfig(env = process.env) {
+  const configuredFallbackModels = core.getInput('gemini-fallback-models') || env.GEMINI_FALLBACK_MODELS || '';
+  const parsedRetries = Number.parseInt(core.getInput('gemini-retries') || env.GEMINI_RETRIES || '3', 10);
+
   const config = {
     geminiApiKey: core.getInput('gemini-api-key') || env.GEMINI_API_KEY,
+    geminiModel: core.getInput('gemini-model') || env.GEMINI_MODEL || 'gemini-2.5-flash',
+    geminiFallbackModels: configuredFallbackModels
+      .split(',')
+      .map(model => model.trim())
+      .filter(Boolean),
+    geminiRetries: Number.isNaN(parsedRetries) || parsedRetries < 0 ? 3 : parsedRetries,
     githubToken: core.getInput('github-token') || env.GITHUB_TOKEN,
     debug: core.getInput('debug') === 'true' || env.DEBUG === 'true',
     githubRepo: env.GITHUB_REPOSITORY,

--- a/src/gemini/analyzer.js
+++ b/src/gemini/analyzer.js
@@ -6,11 +6,17 @@ export class IssueAnalyzer {
   }
 
   async analyzeIssue(issueData) {
+    const maxBodyLength = 4000;
+    const trimmedBody = (issueData.body || '').slice(0, maxBodyLength);
+    const bodyWasTrimmed = (issueData.body || '').length > maxBodyLength;
+    const preferredModel = (issueData.body || '').length > 8000 ? 'gemini-2.5-pro' : undefined;
+
     const prompt = `
       Analyze the following GitHub issue and provide a structured JSON response.
       
       Issue Title: ${issueData.title}
-      Issue Body: ${issueData.body}
+      Issue Body: ${trimmedBody}
+      ${bodyWasTrimmed ? 'Note: The body was truncated for performance. Prioritize key technical points.' : ''}
       Labels: ${issueData.labels.join(', ')}
       
       Requirements:
@@ -33,7 +39,7 @@ export class IssueAnalyzer {
       }
     `;
 
-    const analysis = await this.client.generateJson(prompt);
+    const analysis = await this.client.generateJson(prompt, undefined, { preferredModel });
     return analysis;
   }
 }

--- a/src/gemini/api-client.js
+++ b/src/gemini/api-client.js
@@ -2,35 +2,61 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { delay as defaultDelay } from '../utils/helpers.js';
 
 export class GeminiClient {
-  constructor(apiKey, modelName = 'gemini-1.5-flash', delayFn = defaultDelay) {
+  constructor(apiKey, modelOrOptions = 'gemini-2.5-flash', delayFn = defaultDelay) {
     this.genAI = new GoogleGenerativeAI(apiKey);
-    this.model = this.genAI.getGenerativeModel({ model: modelName });
     this.delay = delayFn;
+    const options = typeof modelOrOptions === 'string'
+      ? { primaryModel: modelOrOptions }
+      : (modelOrOptions || {});
+
+    this.primaryModel = options.primaryModel || 'gemini-2.5-flash';
+    this.fallbackModels = (options.fallbackModels || []).filter(Boolean);
+    this.retries = Number.isInteger(options.retries) && options.retries >= 0 ? options.retries : 3;
+    this.models = new Map();
   }
 
-  async generateContent(prompt, retries = 3) {
+  getModel(modelName) {
+    if (!this.models.has(modelName)) {
+      this.models.set(modelName, this.genAI.getGenerativeModel({ model: modelName }));
+    }
+    return this.models.get(modelName);
+  }
+
+  getCandidateModels(preferredModel) {
+    const candidates = [preferredModel, this.primaryModel, ...this.fallbackModels].filter(Boolean);
+    return [...new Set(candidates)];
+  }
+
+  async generateContent(prompt, retries = this.retries, options = {}) {
     let lastError;
+    const candidateModels = this.getCandidateModels(options.preferredModel);
+
     for (let i = 0; i <= retries; i++) {
-      try {
-        const result = await this.model.generateContent(prompt);
-        const response = await result.response;
-        return response.text();
-      } catch (error) {
-        lastError = error;
-        if (i < retries) {
-          const waitTime = Math.pow(2, i) * 1000;
-          await this.delay(waitTime);
+      for (const modelName of candidateModels) {
+        try {
+          const model = this.getModel(modelName);
+          const result = await model.generateContent(prompt);
+          const response = await result.response;
+          return response.text();
+        } catch (error) {
+          lastError = error;
         }
       }
+
+      if (i < retries) {
+        const waitTime = Math.pow(2, i) * 1000;
+        await this.delay(waitTime);
+      }
     }
+
     throw lastError;
   }
 
-  async generateJson(prompt, retries = 3) {
+  async generateJson(prompt, retries = this.retries, options = {}) {
       const jsonPrompt = `${prompt}
 
 IMPORTANT: Return ONLY valid JSON.`;
-      const text = await this.generateContent(jsonPrompt, retries);
+      const text = await this.generateContent(jsonPrompt, retries, options);
       try {
           // Find JSON block if it exists
           const jsonMatch = text.match(/\{[\s\S]*\}|\[[\s\S]*\]/);


### PR DESCRIPTION
### Motivation

- Ensure the codebase and docs consistently use the Gemini 2.5 family as the default model selection instead of 1.5. 
- Prefer a 2.5 Pro generation model for very large issue bodies to improve generation quality for long inputs. 
- Keep runtime configuration and tests aligned with the new default so behavior is predictable in CI and users can override via inputs. 

### Description

- Change the Gemini client default and internal primary model to `gemini-2.5-flash` and add support for providing `primaryModel`, `fallbackModels`, and `retries` via an options object in `src/gemini/api-client.js`. 
- Update the runtime configuration parsing to default `GEMINI_MODEL` to `gemini-2.5-flash`, parse `gemini-fallback-models` into an array, and parse `gemini-retries` in `src/config/index.js`. 
- Modify `IssueAnalyzer` to truncate long issue bodies for performance and prefer `gemini-2.5-pro` for very large bodies in `src/gemini/analyzer.js`. 
- Pass the configured model/fallbacks/retries into the client in `action.js` and expose new action inputs in `action.yml`. 
- Update documentation in `README.md` to reference the 2.5 defaults and refresh the retry test fixture in `__tests__/properties/retry-logic.test.js` to use `gemini-2.5-flash` and the new mocking approach. 

### Testing

- Ran targeted unit tests with Jest using `node --experimental-vm-modules node_modules/jest/bin/jest.js __tests__/properties/retry-logic.test.js __tests__/properties/config.test.js __tests__/properties/analyzer.test.js --runInBand --testTimeout=20000` and all suites passed. 
- Test summary: `Test Suites: 3 passed, 3 total` and `Tests: 4 passed, 4 total`. 
- Also ran the broader Jest runs used during development and observed `PASS` for the updated retry and kanban-data suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c43ae656083318215a40a839e9585)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the default Gemini model to the 2.5 family and add flexible model selection with fallbacks and retries for better performance and long-input handling. Analyzer trims long issue bodies and prefers 2.5 Pro for very large issues; action inputs, docs, and tests updated.

- **New Features**
  - Default model set to gemini-2.5-flash; config and README updated.
  - GeminiClient supports primary/fallback models, retries, and a request-level preferredModel with exponential backoff.
  - Runtime config parses GEMINI_MODEL, GEMINI_FALLBACK_MODELS, GEMINI_RETRIES; action passes them via new inputs.
  - IssueAnalyzer trims body to 4,000 chars and prefers gemini-2.5-pro for very large bodies; retry test updated.

- **Migration**
  - No changes required; new defaults apply.
  - To override, use action inputs or env vars: GEMINI_MODEL, GEMINI_FALLBACK_MODELS, GEMINI_RETRIES.

<sup>Written for commit ebbc9d832746e07f18e62ca4ff0bc3db4fbf809d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Gemini model selection with fallback support
  * Added adjustable retry count for API calls
  * Implemented smart model selection based on issue complexity
  * Enhanced handling of large issues with automatic content trimming

* **Documentation**
  * Added recommended settings guide for performance optimization and model configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->